### PR TITLE
feat :: [#47] header에 닉네임 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import './styles/global.css'
+import './styles/Global.css'
 import { ThemeProvider } from 'styled-components'
 import { theme } from './styles/Theme'
 import GlobalStyle from './styles/GlobalStyle'

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -62,3 +62,16 @@ export const useChangeProfileImg = (option: MutateOptions, file: File) => {
     },
   })
 }
+
+
+export const useUserQuery = () => {
+  return useQuery({
+    queryKey: ['user'],
+    queryFn: async () => {
+      const {data} = await instance.get<{accountId:string}>(`${router}/accountId`)
+      return data
+    },
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,15 +4,29 @@ import { Tab } from './Tab'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { Button } from './Button'
 import { cookie } from '../utils/Auth'
+import { useUserQuery } from '../apis/user'
+import { useUserStore } from '../stores/UserStores'
+import { useEffect } from 'react'
 
 export const Header = () => {
+  const setUser = useUserStore((state) => state.setUser)
+  const user = useUserStore((state) => state.user)
+
+  const { data } = useUserQuery()
+
+  useEffect(() => {
+    if (data) {
+      setUser(data)
+    }
+  }, [data, setUser])
+
   const routerList = [
     {
       router: '/main',
       name: '메인',
     },
     {
-      router: '/instrument',
+      router: '/instrument?name=피아노',
       name: '가상악기',
     },
     {
@@ -41,7 +55,7 @@ export const Header = () => {
         {isLogin ? (
           <ProfileContainer onClick={() => router('/mypage')}>
             <ProfileImg src={Profile} alt="프로필" />
-            <Nickname>닉네임</Nickname>
+            <Nickname>{user?.accountId}</Nickname>
           </ProfileContainer>
         ) : (
           <RightContainer>

--- a/src/pages/mypage/Edit.tsx
+++ b/src/pages/mypage/Edit.tsx
@@ -6,6 +6,7 @@ import { Button } from '../../components/Button'
 import { useChangeProfileImg, useDuplicateCheck, useEditMypage, useGetMyInformation } from '../../apis/user'
 import { editMypage, position, positionEnum } from '../../apis/user/type'
 import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
 
 export const EditMyPage = () => {
   const navigator = useNavigate()
@@ -16,6 +17,8 @@ export const EditMyPage = () => {
   const [data, setData] = useState<editMypage>({ accountId: '', aboutMe: '', position: [] })
   const [isUsernameChecked, setIsUsernameChecked] = useState<boolean>(true)
   const [isUsernameDuplicate, setIsUsernameDuplicate] = useState<boolean>(false)
+
+  const queryClient = useQueryClient()
 
   const { mutate: changeProfileImg } = useChangeProfileImg(
     {
@@ -29,7 +32,10 @@ export const EditMyPage = () => {
 
   const { mutate: editMypageMutate } = useEditMypage(
     {
-      onSuccess: () => navigator('/mypage'),
+      onSuccess: () => {
+        navigator('/mypage')
+        queryClient.invalidateQueries({ queryKey: ['user'] })
+      },
       onError: () => alert('잠시 후 시도해주세요'),
     },
     data,

--- a/src/stores/UserStores.ts
+++ b/src/stores/UserStores.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+type User = {
+  accountId: string;
+};
+
+type UserStore = {
+  user: User | null;
+  setUser: (user: User) => void;
+  clearUser: () => void;
+};
+
+export const useUserStore = create<UserStore>((set) => ({
+  user: null,
+  setUser: (user) => set({ user }),
+  clearUser: () => set({ user: null }),
+}));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 사용자 정보를 가져오는 React Query 훅이 추가되어, 로그인된 사용자의 계정 정보를 동적으로 표시합니다.
  - 전역 사용자 상태 관리를 위한 스토어가 도입되었습니다.

- **기능 개선**
  - 헤더에서 프로필 닉네임이 실제 로그인한 사용자의 계정 ID로 표시됩니다.
  - "가상악기" 탭의 경로가 `/instrument`에서 `/instrument?name=피아노`로 변경되었습니다.
  - 마이페이지에서 프로필 수정 후 사용자 정보가 자동으로 최신 상태로 반영됩니다.

- **스타일**
  - 글로벌 CSS 파일의 이름이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->