### PR TITLE
feat :: [#58] 가상악기 기타 소리 변경

### DIFF
--- a/src/components/Drum.tsx
+++ b/src/components/Drum.tsx
@@ -16,10 +16,9 @@ export const DrumComponents = () => {
   }
 
   useEffect(() => {
-    const audios: HTMLAudioElement[] = SOUND_LIST.map((sound) => {
+    SOUND_LIST.map((sound) => {
       const audio = new Audio(`${SOUND_URL}/${sound}.mp3`)
       audio.load()
-      return audio
     })
   }, [])
 

--- a/src/components/Drum.tsx
+++ b/src/components/Drum.tsx
@@ -27,18 +27,18 @@ export const DrumComponents = () => {
     KeyZ: 'bass',
   }
 
-  const onKeyDown = (e: KeyboardEvent) => {
-    if (!pressedKeys.current.has(e.code) && keyMap[e.code]) {
-      pressedKeys.current.add(e.code)
-      play(keyMap[e.code])
-    }
-  }
-
-  const onKeyUp = (e: KeyboardEvent) => {
-    pressedKeys.current.delete(e.code)
-  }
-
   useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!pressedKeys.current.has(e.code) && keyMap[e.code]) {
+        pressedKeys.current.add(e.code)
+        play(keyMap[e.code])
+      }
+    }
+
+    const onKeyUp = (e: KeyboardEvent) => {
+      pressedKeys.current.delete(e.code)
+    }
+
     window.addEventListener('keydown', onKeyDown)
     window.addEventListener('keyup', onKeyUp)
     return () => {

--- a/src/components/Drum.tsx
+++ b/src/components/Drum.tsx
@@ -1,10 +1,13 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import { DrumImage, HiHat, Crash, Ride, LargeTom, FloorTom, SmallTom, Snare, Kick, Pedal } from '../assets'
 import { DrumElement } from './DrumElement'
 
 const SOUND_URL = import.meta.env.VITE_DRUM_SOUND
+const SOUND_LIST = ['hihat', 'crash', 'ride', 'snare-drum', 'tom1', 'tom2', 'floor-tom', 'hihat-foot', 'bass']
+
 export const DrumComponents = () => {
+  const pressedKeys = useRef<Set<string>>(new Set())
   const play = (sound: string) => {
     const audio = new Audio(`${SOUND_URL}/${sound}.mp3`)
     audio.play().catch((error) => {
@@ -12,21 +15,36 @@ export const DrumComponents = () => {
     })
   }
 
+  useEffect(() => {
+    const audios: HTMLAudioElement[] = SOUND_LIST.map((sound) => {
+      const audio = new Audio(`${SOUND_URL}/${sound}.mp3`)
+      audio.load()
+      return audio
+    })
+  }, [])
+
   const keyMap: Record<string, string> = {
     KeyX: 'hihat-foot',
     KeyZ: 'bass',
   }
 
-  const onKeyDown = (event: KeyboardEvent) => {
-    if (keyMap[event.code]) {
-      play(keyMap[event.code])
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (!pressedKeys.current.has(e.code) && keyMap[e.code]) {
+      pressedKeys.current.add(e.code)
+      play(keyMap[e.code])
     }
+  }
+
+  const onKeyUp = (e: KeyboardEvent) => {
+    pressedKeys.current.delete(e.code)
   }
 
   useEffect(() => {
     window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
     return () => {
       window.removeEventListener('keydown', onKeyDown)
+      window.addEventListener('keyup', onKeyUp)
     }
   }, [])
 
@@ -35,13 +53,13 @@ export const DrumComponents = () => {
       <Layout>
         <ImageBox>
           <img src={DrumImage} />
-          <DrumElement type="cymbal" note="Q" style={{ top: '162px', left: '27px' }} src={HiHat} onClick={() => play('hihat')} />
-          <DrumElement type="cymbal" note="W" style={{ top: '12px', left: '149px' }} src={Crash} onClick={() => play('crash')} />
-          <DrumElement type="cymbal" note="E" style={{ top: '100px', right: '45px' }} src={Ride} onClick={() => play('ride')} />
-          <DrumElement note="A" style={{ top: '282px', left: '207px' }} src={Snare} onClick={() => play('snare-drum')} />
-          <DrumElement note="S" style={{ top: '150px', left: '245px' }} src={SmallTom} onClick={() => play('tom1')} />
-          <DrumElement note="D" style={{ top: '150px', right: '217px' }} src={LargeTom} onClick={() => play('tom2')} />
-          <DrumElement note="F" style={{ top: '257px', right: '129px' }} src={FloorTom} onClick={() => play('floor-tom')} />
+          <DrumElement type="cymbal" note="q" style={{ top: '162px', left: '27px' }} src={HiHat} onClick={() => play('hihat')} />
+          <DrumElement type="cymbal" note="w" style={{ top: '12px', left: '149px' }} src={Crash} onClick={() => play('crash')} />
+          <DrumElement type="cymbal" note="e" style={{ top: '100px', right: '45px' }} src={Ride} onClick={() => play('ride')} />
+          <DrumElement note="a" style={{ top: '282px', left: '207px' }} src={Snare} onClick={() => play('snare-drum')} />
+          <DrumElement note="s" style={{ top: '150px', left: '245px' }} src={SmallTom} onClick={() => play('tom1')} />
+          <DrumElement note="d" style={{ top: '150px', right: '217px' }} src={LargeTom} onClick={() => play('tom2')} />
+          <DrumElement note="f" style={{ top: '257px', right: '129px' }} src={FloorTom} onClick={() => play('floor-tom')} />
           <PedalImg src={Pedal} onClick={() => play('hihat-foot')} />
           <KickImg src={Kick} onClick={() => play('bass')} />
         </ImageBox>

--- a/src/components/Drum.tsx
+++ b/src/components/Drum.tsx
@@ -44,7 +44,7 @@ export const DrumComponents = () => {
     window.addEventListener('keyup', onKeyUp)
     return () => {
       window.removeEventListener('keydown', onKeyDown)
-      window.addEventListener('keyup', onKeyUp)
+      window.removeEventListener('keyup', onKeyUp)
     }
   }, [])
 

--- a/src/components/DrumElement.tsx
+++ b/src/components/DrumElement.tsx
@@ -41,15 +41,15 @@ export const DrumElement = ({ src, style, onClick, note, type = 'tom' }: Element
     }
   }, [])
 
-  return <Layout type={type} isHit={isHit} style={style} src={src} onMouseDown={handleMouseDown} />
+  return <Layout type={type} $isHit={isHit} style={style} src={src} onMouseDown={handleMouseDown} />
 }
 
-const Layout = styled.img<{ isHit: boolean; type: 'tom' | 'cymbal' }>`
+const Layout = styled.img<{ $isHit: boolean; type: 'tom' | 'cymbal' }>`
   position: absolute;
   z-index: 100;
   cursor: pointer;
 
-  animation: ${({ isHit, type }) => isHit && (type === 'tom' ? 'tomHit 0.3s ease-out' : 'cymbalHit 0.6s ease-out')};
+  animation: ${({ $isHit, type }) => $isHit && (type === 'tom' ? 'tomHit 0.3s ease-out' : 'cymbalHit 0.6s ease-out')};
 
   @keyframes cymbalHit {
     0% {

--- a/src/components/DrumElement.tsx
+++ b/src/components/DrumElement.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import styled, { CSSProperties } from 'styled-components'
 
 interface ElementProps {
@@ -11,6 +11,7 @@ interface ElementProps {
 
 export const DrumElement = ({ src, style, onClick, note, type = 'tom' }: ElementProps) => {
   const [isHit, setIsHit] = useState(false)
+  const pressedKeys = useRef<Set<string>>(new Set())
 
   const handleMouseDown = () => {
     onClick()
@@ -19,17 +20,26 @@ export const DrumElement = ({ src, style, onClick, note, type = 'tom' }: Element
   }
 
   const onKeyDown = (e: KeyboardEvent) => {
-    if (note === e.key.toUpperCase()) {
+    if (e.key.toLowerCase() === note && !pressedKeys.current.has(note)) {
+      pressedKeys.current.add(note)
       handleMouseDown()
+    }
+  }
+
+  const onKeyUp = (e: KeyboardEvent) => {
+    if (e.key.toLowerCase() === note) {
+      pressedKeys.current.delete(note)
     }
   }
 
   useEffect(() => {
     window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
     return () => {
       window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
     }
-  }, [onKeyDown])
+  }, [])
 
   return <Layout type={type} isHit={isHit} style={style} src={src} onMouseDown={handleMouseDown} />
 }

--- a/src/components/Guitar.tsx
+++ b/src/components/Guitar.tsx
@@ -1,34 +1,35 @@
 import { useEffect } from 'react'
 import styled from 'styled-components'
-import * as Tone from 'tone'
+
+const f = Array.from({ length: 14 }, (_, i) => `f${i + 1}`)
+const h = Array.from({ length: 5 }, (_, i) => `h${i + 1}`)
+const g = Array.from({ length: 4 }, (_, i) => `g${i + 1}`)
+const d = Array.from({ length: 5 }, (_, i) => `d${i + 1}`)
+const a = Array.from({ length: 5 }, (_, i) => `a${i + 1}`)
+const e = Array.from({ length: 5 }, (_, i) => `e${i + 1}`)
+
+const STRINGS = [
+  { h: 2, frets: f },
+  { h: 2.4, frets: [...h, ...f].slice(0, 14) },
+  { h: 3, frets: [...g, ...h, ...f].slice(0, 14) },
+  { h: 3.6, frets: [...d, ...g, ...h].slice(0, 14) },
+  { h: 4.2, frets: [...a, ...d, ...g] },
+  { h: 5, frets: [...e, ...a, ...d].slice(0, 14) },
+]
+const SOUND_URL = import.meta.env.VITE_GUITAR_SOUND_URL
 
 function GuitarComponents() {
-  const guitarFrets = [2, 2.4, 3, 3.6, 4.2, 5]
   const inlayPositions = [2, 4, 6, 8, 11]
   const doubleInlayPositions = [11]
-  const newSynth = new Tone.PolySynth(Tone.Synth).toDestination()
-  newSynth.set({
-    oscillator: {
-      type: 'fmsine',
-    },
-    envelope: {
-      attack: 0.01,
-      decay: 0.2,
-      sustain: 0.5,
-      release: 1.5,
-    },
-  })
-  const synth: Tone.PolySynth<Tone.Synth<Tone.SynthOptions>> | null = newSynth
 
-  const openStringNotes = ['E4', 'B3', 'G3', 'D3', 'A2', 'E2']
   const keyBindings = ['!@#$%^&*()_+', 'QWERTYUIOP[]|', '1234567890-=', 'qwertyuiop[]]\\', "asdfghjkl;'", 'zxcvbnm,./']
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      keyBindings.map((keys, stringIndex) => {
+      keyBindings.forEach((keys, stringIndex) => {
         const fretIndex = keys.indexOf(e.key)
         if (fretIndex !== -1) {
-          playString(stringIndex, fretIndex)
+          play(STRINGS[stringIndex].frets[fretIndex])
         }
       })
     }
@@ -39,32 +40,22 @@ function GuitarComponents() {
     }
   }, [])
 
-  const getNoteFromFret = (stringIndex: number, fretIndex: number) => {
-    const baseNote = openStringNotes[stringIndex]
-    if (fretIndex === 0) return baseNote
-    return Tone.Frequency(baseNote).transpose(fretIndex).toNote()
-  }
-
-  const playString = (stringIndex: number, fretIndex: number) => {
-    if (synth) {
-      const note = getNoteFromFret(stringIndex, fretIndex)
-      synth?.triggerAttackRelease(note, '8n')
-    }
+  const play = (sound: string) => {
+    const audio = new Audio(`${SOUND_URL}/${sound}.mp3`)
+    audio.play()
   }
 
   return (
     <Container>
       <Fretboard>
-        {guitarFrets.map((h, lineIndex) => (
-          <FretBox key={`string-${lineIndex}`}>
-            <GuitarString height={h} />
-            {Array.from({ length: 13 }).map((_, fretIndex) => (
-              <Fret key={`fret-${lineIndex}-${fretIndex}`} onClick={() => playString(lineIndex, fretIndex)}>
-                {lineIndex === 2 && inlayPositions.includes(fretIndex) && <InlayDot double={doubleInlayPositions.includes(fretIndex)} />}
-              </Fret>
-            ))}
-          </FretBox>
-        ))}
+        {STRINGS.map(({ h, frets }, stringIndex) =>
+          frets.map((f, fretIndex) => (
+            <FretCell key={`fret-${stringIndex}-${fretIndex}`} onClick={() => play(f)}>
+              {fretIndex === 0 && <GuitarString height={h} />}
+              {stringIndex === 2 && inlayPositions.includes(fretIndex) && <InlayDot $double={doubleInlayPositions.includes(fretIndex)} />}
+            </FretCell>
+          )),
+        )}
       </Fretboard>
     </Container>
   )
@@ -77,14 +68,18 @@ const Container = styled.div`
   align-items: center;
   height: 70dvh;
 `
-
-const FretBox = styled.div`
-  width: 860px;
-  display: flex;
+const Fretboard = styled.div`
+  display: grid;
+  grid-template-columns: repeat(14, 64px);
+  grid-template-rows: repeat(6, 35px);
+  background-color: ${({ theme }) => theme.color.gray100};
+  border-radius: 5px;
+  overflow: hidden;
+  border: 1px solid ${({ theme }) => theme.color.gray200};
   position: relative;
 `
 
-const Fret = styled.div`
+const FretCell = styled.div`
   width: 64px;
   height: 35px;
   border-right: 1px solid ${({ theme }) => theme.color.gray700};
@@ -93,23 +88,6 @@ const Fret = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-
-  &:hover {
-    background-color: ${({ theme }) => theme.color.gray200};
-  }
-
-  &:active {
-    background-color: rgba(255, 255, 255, 0.2);
-  }
-`
-
-const Fretboard = styled.div`
-  display: flex;
-  flex-direction: column;
-  background-color: ${({ theme }) => theme.color.gray100};
-  border-radius: 5px;
-  overflow: hidden;
-  border: 1px solid ${({ theme }) => theme.color.gray200};
 `
 
 const GuitarString = styled.span<{ height: number; isActive?: boolean }>`
@@ -122,32 +100,30 @@ const GuitarString = styled.span<{ height: number; isActive?: boolean }>`
   z-index: 10;
   position: absolute;
   align-self: center;
-  width: 100%;
+  width: 200vh;
   box-shadow: 10px 5px 2px rgba(0, 0, 0, 0.1);
 `
 
-const InlayDot = styled.div<{ double?: boolean }>`
+const InlayDot = styled.div<{ $double?: boolean }>`
   width: 12px;
   height: 12px;
   border-radius: 50%;
   background-color: ${({ theme }) => theme.color.gray500};
   position: absolute;
   z-index: 5;
-  top: ${({ double }) => (double ? -41 : 29)}px;
+  top: ${({ $double }) => ($double ? -41 : 29)}px;
 
-  ${(props) =>
-    props.double &&
-    `
-    &:before {
+  ${({ $double, theme }) =>
+    $double &&
+    `&:before {
       content: '';
       position: absolute;
       width: 12px;
       height: 12px;
       border-radius: 50%;
-      background-color: ${props.theme.color.gray600};
+      background-color: ${theme.color.gray600};
       top: 140px;
-    }
-  `}
+    }`}
 `
 
 export default GuitarComponents

--- a/src/components/Guitar.tsx
+++ b/src/components/Guitar.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import styled from 'styled-components'
 
 const f = Array.from({ length: 14 }, (_, i) => `f${i + 1}`)
@@ -19,24 +19,33 @@ const STRINGS = [
 const SOUND_URL = import.meta.env.VITE_GUITAR_SOUND_URL
 
 function GuitarComponents() {
+  const pressedKeys = useRef<Set<string>>(new Set())
   const inlayPositions = [2, 4, 6, 8, 11]
   const doubleInlayPositions = [11]
 
   const keyBindings = ['!@#$%^&*()_+', 'QWERTYUIOP[]|', '1234567890-=', 'qwertyuiop[]]\\', "asdfghjkl;'", 'zxcvbnm,./']
 
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (pressedKeys.current.has(e.key)) return
       keyBindings.forEach((keys, stringIndex) => {
         const fretIndex = keys.indexOf(e.key)
         if (fretIndex !== -1) {
+          pressedKeys.current.add(e.key)
           play(STRINGS[stringIndex].frets[fretIndex])
         }
       })
     }
 
-    window.addEventListener('keydown', handleKeyDown)
+    const onKeyUp = (e: KeyboardEvent) => {
+      pressedKeys.current.delete(e.key)
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
     return () => {
-      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
     }
   }, [])
 

--- a/src/components/Guitar.tsx
+++ b/src/components/Guitar.tsx
@@ -51,7 +51,9 @@ function GuitarComponents() {
 
   const play = (sound: string) => {
     const audio = new Audio(`${SOUND_URL}/${sound}.mp3`)
-    audio.play()
+    audio.play().catch((err) => {
+      console.log('기타 사운드 재생 오류:', err)
+    })
   }
 
   return (


### PR DESCRIPTION
- 기타 사운드 변경
- 줄 요소가 앞에 나와있어 프렛이 클릭 안되는 문제 ✅
- 드럼, 기타에서 키를 계속 누르고 있을 경우 소리 반복 재생 ✅
- 드럼 mp3 파일 로딩 지연 ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 드럼과 기타 컴포넌트에 오디오 파일을 사전 로드하여, 키보드 입력 또는 클릭 시 빠른 소리 재생이 가능합니다.
- **버그 수정**
    - 키보드 키를 길게 누를 때 소리가 반복 재생되지 않도록 개선되었습니다.
    - 키보드 입력이 대소문자 구분 없이 동작하도록 수정되었습니다.
- **개선 사항**
    - 기타 소리가 동적 합성에서 사전 녹음된 오디오 파일 재생으로 변경되어 보다 실제와 가까운 사운드를 제공합니다.
    - 기타 프렛보드 UI가 그리드 레이아웃으로 변경되어 가시성과 사용성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->